### PR TITLE
Use Notion as CMS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@next/third-parties": "^14.1.0",
+        "@notionhq/client": "^2.2.14",
         "@radix-ui/react-avatar": "^1.0.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -431,6 +432,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@notionhq/client": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.14.tgz",
+      "integrity": "sha512-oqUefZtCiJPCX+74A1Os9OVTef3fSnVWe2eVQtU1HJSD+nsfxfhwvDKnzJTh2Tw1ZHKLxpieHB/nzGdY+Uo12A==",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -599,9 +612,17 @@
       "version": "20.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
       "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1033,6 +1054,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.17",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
@@ -1329,6 +1355,17 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1432,6 +1469,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -2216,6 +2261,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -3167,6 +3225,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3305,6 +3382,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -4528,6 +4624,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
@@ -4682,8 +4783,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -4728,6 +4828,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@next/third-parties": "^14.1.0",
+    "@notionhq/client": "^2.2.14",
     "@radix-ui/react-avatar": "^1.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { URL_LINKEDIN, URL_WANTEDLY, MAIL } from "../constants/identity"
+import { MAIL } from "../constants/identity"
 import { Author } from "@/components/Author"
 import { Contact } from "@/components/Contact"
 import { WorkExperience } from "@/components/WorkExperience"
@@ -12,7 +12,7 @@ type SectionElement = {
 const SectionElements: SectionElement[] = [
   {
     title: "Author",
-    content: <Author urlLinkedin={URL_LINKEDIN} urlWantedly={URL_WANTEDLY} />,
+    content: <Author />,
   },
   {
     title: "Work Experience",

--- a/src/components/Author.tsx
+++ b/src/components/Author.tsx
@@ -1,25 +1,20 @@
 import React from 'react'
+import { getAuthorData } from '@/lib/cmsClient';
 
-type AuthorProps = {
-    urlLinkedin: string;
-    urlWantedly: string;
-}
+export const Author: React.FC = async () => {
+    const contents = await getAuthorData()
 
-export const Author: React.FC<AuthorProps> = ({ urlLinkedin, urlWantedly }) => {
     return (
         <React.Fragment>
-            <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
-                Web(Full-stack) Developer, Tennis and Snowboard Lover. 🧑‍💻🎾🏂
-            </p>
-            <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">
-                I have experience in a
-                variety of technologies and I&apos;m always looking for new challenges to improve User Interface and Developer Experience.
-                <br />
-                <br />
-                Please see these links for more information.
-            </p>
-            <a href={urlLinkedin} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:text-blue-900">LinkedIn</a>
-            , <a href={urlWantedly} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800">Wantedly</a>
+            {contents && contents.results.map((block) => {
+                // @ts-ignore
+                const text = block[block.type]['rich_text'][0].text
+                const content = text.content
+                const link = text.link
+                return link ?
+                    <a key={block.id} href={link.url} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:text-blue-900">{content}, </a> :
+                    <p key={block.id} className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">{content}</p>
+            })}
         </React.Fragment>
     )
 }

--- a/src/components/Author.tsx
+++ b/src/components/Author.tsx
@@ -1,19 +1,36 @@
 import React from 'react'
-import { getAuthorData } from '@/lib/cmsClient';
+import { getAuthorData } from '@/lib/cmsClient'
 
-export const Author: React.FC = async () => {
+type AuthorLinkProps = {
+    link: { url: string }
+    content: string
+}
+const AuthorLink: React.FC<AuthorLinkProps> = ({ link, content }) => (
+    <a href={link.url} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:text-blue-900">{content}, </a>
+)
+
+type AuthorParagraphProps = {
+    content: string
+}
+const AuthorParagraph: React.FC<AuthorParagraphProps> = ({ content }) => (
+    <p className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">{content}</p>
+)
+
+export const Author = async (): Promise<React.JSX.Element> => {
     const contents = await getAuthorData()
+
+    if (contents === null) return <p>Failed to fetch author data</p>
 
     return (
         <React.Fragment>
-            {contents && contents.results.map((block) => {
+            {contents.results.map((block) => {
                 // @ts-ignore
                 const text = block[block.type]['rich_text'][0].text
                 const content = text.content
                 const link = text.link
                 return link ?
-                    <a key={block.id} href={link.url} target="_blank" rel="noopener noreferrer" className="text-blue-700 hover:text-blue-900">{content}, </a> :
-                    <p key={block.id} className="mx-auto max-w-[700px] text-gray-500 md:text-xl dark:text-gray-400">{content}</p>
+                    <AuthorLink key={block.id} link={link.url} content={content} /> :
+                    <AuthorParagraph key={block.id} content={content} />
             })}
         </React.Fragment>
     )

--- a/src/components/WorkExperience.tsx
+++ b/src/components/WorkExperience.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export const WorkExperience: React.FC = () => {
+export const WorkExperience: React.FC<{}> = () => {
     return (
         <React.Fragment>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">

--- a/src/constants/identity.ts
+++ b/src/constants/identity.ts
@@ -12,7 +12,6 @@ const URL_LINKEDIN = `${PREFIX}www.linkedin.com/in/narumi-nogawa-a94413198/`
 const URL_QIITA = `${PREFIX}qiita.com/chan_naruwo`
 const URL_ROOT = `${PREFIX}naruwo-github.github.io`
 const URL_TWITTER = `${PREFIX}twitter.com/chan_naru_way`
-const URL_WANTEDLY = `${PREFIX}www.wantedly.com/id/narunaru_chan`
 export {
   URL_GITHUB,
   URL_HATENA,
@@ -20,6 +19,5 @@ export {
   URL_LINKEDIN,
   URL_QIITA,
   URL_ROOT,
-  URL_TWITTER,
-  URL_WANTEDLY
+  URL_TWITTER
 }

--- a/src/lib/cmsClient.ts
+++ b/src/lib/cmsClient.ts
@@ -12,26 +12,36 @@ const notion = new Client({
   auth: apiSecret
 })
 
+// TODO: Move to /app/api/author
 export const getAuthorData =
   async (): Promise<ListBlockChildrenResponse | null> => {
-    if (!authorPageId) {
+    if (!authorPageId) return null
+
+    try {
+      const contents = await notion.blocks.children.list({
+        block_id: authorPageId
+      })
+      return contents
+    } catch (error) {
+      // TODO: Introduce a mechanism to collect logs
+      console.error('Failed to fetch author data: ', error)
       return null
     }
-
-    const contents = await notion.blocks.children.list({
-      block_id: authorPageId
-    })
-    return contents
   }
 
+// TODO: Move to /app/api/work-experience
 export const getWorkExperienceData =
   async (): Promise<QueryDatabaseResponse | null> => {
-    if (!workExperiencePageId) {
+    if (!workExperiencePageId) return null
+
+    try {
+      const contents = await notion.databases.query({
+        database_id: workExperiencePageId
+      })
+      return contents
+    } catch (error) {
+      // TODO: Introduce a mechanism to collect logs
+      console.error('Failed to fetch work experience data: ', error)
       return null
     }
-
-    const contents = await notion.databases.query({
-      database_id: workExperiencePageId
-    })
-    return contents
   }

--- a/src/lib/cmsClient.ts
+++ b/src/lib/cmsClient.ts
@@ -1,0 +1,37 @@
+import { Client } from '@notionhq/client'
+import {
+  ListBlockChildrenResponse,
+  QueryDatabaseResponse
+} from '@notionhq/client/build/src/api-endpoints'
+
+const apiSecret = process.env.NOTION_API_SECRET
+const authorPageId = process.env.NOTION_AUTHOR_PAGE_ID
+const workExperiencePageId = process.env.NOTION_WORK_EXPERIENCE_PAGE_ID
+
+const notion = new Client({
+  auth: apiSecret
+})
+
+export const getAuthorData =
+  async (): Promise<ListBlockChildrenResponse | null> => {
+    if (!authorPageId) {
+      return null
+    }
+
+    const contents = await notion.blocks.children.list({
+      block_id: authorPageId
+    })
+    return contents
+  }
+
+export const getWorkExperienceData =
+  async (): Promise<QueryDatabaseResponse | null> => {
+    if (!workExperiencePageId) {
+      return null
+    }
+
+    const contents = await notion.databases.query({
+      database_id: workExperiencePageId
+    })
+    return contents
+  }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Updated `Author` and `WorkExperience` components to fetch data dynamically from a CMS using the Notion API, enhancing content flexibility and maintainability.
- Refactor: Removed static imports of `URL_LINKEDIN` and `URL_WANTEDLY` in `page.tsx` and `identity.ts`, replacing them with dynamic data fetching.
- Chore: Added new utility functions `getAuthorData` and `getWorkExperienceData` in `cmsClient.ts` for retrieving data from the CMS.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->